### PR TITLE
use thiserror and anyhow to improve errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- The `FormaError` type now uses `thiserror` and `forma` consumes this via
+`anyhow` for significantly more useful error messages.
 
 ## [0.1.2] - 2020-05-31
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,6 +10,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85bb70cc08ec97ca5450e6eba421deeea5f172c0fc61f78b5357b2a8e8be195f"
+
+[[package]]
 name = "arrayvec"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -220,21 +226,23 @@ checksum = "bb1f6b1ce1c140482ea30ddd3335fc0024ac7ee112895426e0a629a6c20adfe3"
 
 [[package]]
 name = "forma"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
+ "anyhow",
  "formation",
  "structopt",
 ]
 
 [[package]]
 name = "formation"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "criterion",
  "pretty",
  "pretty_assertions",
  "rstest",
  "sqlparser",
+ "thiserror",
 ]
 
 [[package]]
@@ -635,6 +643,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b13f926965ad00595dd129fa12823b04bbf866e9085ab0a5f2b05b850fbfc344"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "893582086c2f98cde18f906265a65b5030a074b1046c674ae898be6519a7f479"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/forma/Cargo.toml
+++ b/forma/Cargo.toml
@@ -12,3 +12,4 @@ license = "MIT"
 [dependencies]
 formation = { path = "../formation", version = "0.1.2" }
 structopt = "0.3.14"
+anyhow = "1.0.31"

--- a/forma/src/main.rs
+++ b/forma/src/main.rs
@@ -15,9 +15,10 @@
 use std::fs;
 use std::io::{self, Read, Write};
 use std::path::PathBuf;
-use structopt::StructOpt;
 
+use anyhow::Result;
 use formation::format;
+use structopt::StructOpt;
 
 const DEFAULT_MAX_WIDTH: &str = "100";
 
@@ -38,16 +39,18 @@ struct Opt {
 }
 
 /// Given a writer, writes the given formatted buffers.
-fn write_formatted<W: Write>(mut writer: W, formatted: Vec<String>) -> io::Result<()> {
+fn write_formatted<W: Write>(mut writer: W, formatted: Vec<String>) -> Result<()> {
     writer.write_all(
         &formatted
             .iter()
             .flat_map(|ps| ps.as_bytes().to_owned())
             .collect::<Vec<u8>>()[..],
-    )
+    )?;
+    Ok(())
 }
 
-fn main() -> io::Result<()> {
+/// Main entrypoint for the `forma` binary.
+fn main() -> Result<()> {
     let Opt {
         input,
         check,

--- a/formation/Cargo.toml
+++ b/formation/Cargo.toml
@@ -13,6 +13,7 @@ license = "MIT"
 [dependencies]
 sqlparser = "0.5.0"
 pretty = "0.10.0"
+thiserror = "1.0.19"
 
 [dev-dependencies]
 criterion = "0.3"

--- a/formation/src/doc.rs
+++ b/formation/src/doc.rs
@@ -1,4 +1,4 @@
-use crate::error::{self, FormaError};
+use crate::error;
 use pretty::RcDoc;
 use sqlparser::ast::{
     BinaryOperator, Cte, Expr, Fetch, Function, Join, JoinConstraint, JoinOperator, OrderByExpr,
@@ -637,10 +637,8 @@ fn transform_statement<'a>(statement: Statement) -> RcDoc<'a, ()> {
 /// Renders the `Statement` in accordance with the provided maximum width.
 pub fn render_statement(statement: Statement, max_width: usize) -> error::Result<String> {
     let mut bs = Vec::new();
-    transform_statement(statement)
-        .render(max_width, &mut bs)
-        .map_err(FormaError::TransformationFailure)?;
-    String::from_utf8(bs).map_err(|_| FormaError::Utf8Failure)
+    transform_statement(statement).render(max_width, &mut bs)?;
+    Ok(String::from_utf8(bs)?)
 }
 
 #[cfg(test)]

--- a/formation/src/error.rs
+++ b/formation/src/error.rs
@@ -2,30 +2,30 @@
 //!
 //! Provides a custom error enum representing different errors the formatter can encounter.
 use std::io;
+use std::string::FromUtf8Error;
+
+use sqlparser::parser::ParserError;
+use thiserror::Error;
 
 /// An alias for a `std::result::Result` that pins `FormaError`.
 pub type Result<T> = std::result::Result<T, FormaError>;
 
 /// Forma error type.
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum FormaError {
     /// Unable to parse given input as SQL.
-    InvalidInput,
-    /// Formatting would occur, i.e. when `check` is `true`.
-    WouldFormat,
-    /// A transformation failure that wraps `io::Error`.
-    TransformationFailure(io::Error),
-    /// A UTF-8 failure.
-    Utf8Failure,
-}
+    #[error("Invalid SQL provided as input")]
+    InvalidInput(#[from] ParserError),
 
-impl From<FormaError> for io::Error {
-    fn from(error: FormaError) -> Self {
-        match error {
-            FormaError::InvalidInput => io::Error::new(io::ErrorKind::InvalidData, ""),
-            FormaError::Utf8Failure => io::Error::new(io::ErrorKind::InvalidData, ""),
-            FormaError::WouldFormat => io::Error::new(io::ErrorKind::InvalidData, ""),
-            FormaError::TransformationFailure(err) => err,
-        }
-    }
+    /// Formatting would occur, i.e. when `check` is `true`.
+    #[error("Check failed; would format SQL")]
+    WouldFormat,
+
+    /// A transformation failure that wraps `io::Error`.
+    #[error("Transformation did not succeed")]
+    TransformationFailure(#[from] io::Error),
+
+    /// A UTF-8 failure.
+    #[error("A UTF8 error occurred")]
+    Utf8Failure(#[from] FromUtf8Error),
 }

--- a/formation/src/format.rs
+++ b/formation/src/format.rs
@@ -56,8 +56,7 @@ fn format_statement(
 /// ```
 pub fn format(sql_string: String, check: bool, max_width: usize) -> error::Result<Vec<String>> {
     let dialect = TemplatedDialect {};
-    let statements =
-        Parser::parse_sql(&dialect, sql_string.clone()).map_err(|_| FormaError::InvalidInput)?;
+    let statements = Parser::parse_sql(&dialect, sql_string.clone())?;
     let mut pretty_statements: Vec<String> = vec![];
 
     for statement in statements {


### PR DESCRIPTION
This reworks the `FormaError` type implementation by using `thiserror`
and `anyhow` to do the heavy lifting. Doing so increases the usefulness
of the errors and in particular prevents the previous sitation: all
errors are rendered as `Error: Custom { kind: InvalidData, error: "" }`,
which is not particularly informative.