### PR TITLE
prefer conserving vertical space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Changed
+- All use of `hardline` has been removed and vertical space will be more
+aggressively conserved.
 - The `FormaError` type now uses `thiserror` and `forma` consumes this via
 `anyhow` for significantly more useful error messages.
 

--- a/formation/tests/sql/case_expected.sql
+++ b/formation/tests/sql/case_expected.sql
@@ -1,9 +1,5 @@
 select
-  venuecity,
-  case venuecity
-    when 'New York City' then 'Big Apple'
-    else 'other'
-  end
+  venuecity, case venuecity when 'New York City' then 'Big Apple' else 'other' end
 from
   venue
 order by

--- a/formation/tests/sql/correlated_subquery_expected.sql
+++ b/formation/tests/sql/correlated_subquery_expected.sql
@@ -1,7 +1,5 @@
 select
-  salesid,
-  listid,
-  sum(pricepaid)
+  salesid, listid, sum(pricepaid)
 from
   sales as s
 where

--- a/formation/tests/sql/ctes_expected.sql
+++ b/formation/tests/sql/ctes_expected.sql
@@ -1,24 +1,17 @@
 with venue_sales as (
     select
-      venuename,
-      venuecity,
-      sum(pricepaid) as venuename_sales
+      venuename, venuecity, sum(pricepaid) as venuename_sales
     from
       sales, venue, event
     where
-      venue.venueid = event.venueid
-      and event.eventid = sales.eventid
+      venue.venueid = event.venueid and event.eventid = sales.eventid
     group by
       venuename, venuecity
   ),
   top_venues as (select venuename from venue_sales where venuename_sales > 800000)
 
 select
-  venuename,
-  venuecity,
-  venuestate,
-  sum(qtysold) as venue_qty,
-  sum(pricepaid) as venue_sales
+  venuename, venuecity, venuestate, sum(qtysold) as venue_qty, sum(pricepaid) as venue_sales
 from
   sales, venue, event
 where

--- a/formation/tests/sql/group_by_expected.sql
+++ b/formation/tests/sql/group_by_expected.sql
@@ -1,8 +1,5 @@
 select
-  listid,
-  eventid,
-  sum(pricepaid) as revenue,
-  count(qtysold) as numtix
+  listid, eventid, sum(pricepaid) as revenue, count(qtysold) as numtix
 from
   sales
 group by

--- a/formation/tests/sql/inner_join_expected.sql
+++ b/formation/tests/sql/inner_join_expected.sql
@@ -1,30 +1,23 @@
 select
-  catgroup1,
-  sold,
-  unsold
+  catgroup1, sold, unsold
 from
   (
     select
-      catgroup,
-      sum(qtysold) as sold
+      catgroup, sum(qtysold) as sold
     from
       category as c, event as e, sales as s
     where
-      c.catid = e.catid
-      and e.eventid = s.eventid
+      c.catid = e.catid and e.eventid = s.eventid
     group by
       catgroup
   ) as a (catgroup1, sold)
   join (
     select
-      catgroup,
-      sum(numtickets) - sum(qtysold) as unsold
+      catgroup, sum(numtickets) - sum(qtysold) as unsold
     from
       category as c, event as e, sales as s, listing as l
     where
-      c.catid = e.catid
-      and e.eventid = s.eventid
-      and s.listid = l.listid
+      c.catid = e.catid and e.eventid = s.eventid and s.listid = l.listid
     group by
       catgroup
   ) as b (catgroup2, unsold) on a.catgroup1 = b.catgroup2

--- a/formation/tests/sql/join_using_expected.sql
+++ b/formation/tests/sql/join_using_expected.sql
@@ -1,7 +1,1 @@
-select
-  t1.name as t1_name,
-  t2.name as t2_name,
-  t2.kind
-from
-  t1
-  join t2 using (t1_id);
+select t1.name as t1_name, t2.name as t2_name, t2.kind from t1 join t2 using (t1_id);

--- a/formation/tests/sql/natural_join_expected.sql
+++ b/formation/tests/sql/natural_join_expected.sql
@@ -1,5 +1,1 @@
-select
-  *
-from
-  t1
-  natural join t2;
+select * from t1 natural join t2;

--- a/formation/tests/sql/outer_join_expected.sql
+++ b/formation/tests/sql/outer_join_expected.sql
@@ -1,10 +1,7 @@
 select
-  listing.listid,
-  sum(pricepaid) as price,
-  sum(commission) as comm
+  listing.listid, sum(pricepaid) as price, sum(commission) as comm
 from
-  listing
-  left join sales on sales.listid = listing.listid
+  listing left join sales on sales.listid = listing.listid
 where
   listing.listid between 1 and 5
 group by

--- a/formation/tests/sql/subquery_expected.sql
+++ b/formation/tests/sql/subquery_expected.sql
@@ -5,18 +5,14 @@ select
     select
       sum(pricepaid)
     from
-      sales
-      join _date on sales.dateid = _date.dateid
+      sales join _date on sales.dateid = _date.dateid
     where
-      qtr = '1'
-      and year = 2008
+      qtr = '1' and year = 2008
   ) as q1sales
 from
-  sales
-  join _date on sales.dateid = _date.dateid
+  sales join _date on sales.dateid = _date.dateid
 where
-  qtr in ('2', '3')
-  and year = 2008
+  qtr in ('2', '3') and year = 2008
 group by
   qtr
 order by

--- a/formation/tests/sql/window_function_expected.sql
+++ b/formation/tests/sql/window_function_expected.sql
@@ -1,8 +1,5 @@
 select
-  salesid,
-  sellerid,
-  qty,
-  rank() over(partition by sellerid order by qty desc) as rank
+  salesid, sellerid, qty, rank() over(partition by sellerid order by qty desc) as rank
 from
   winsales
 order by


### PR DESCRIPTION
This removes the use of hardline as well as reworks expressions directly
after select and from such that they will remain on the same line if
they fit within the doc's maximum width. Doing so conserves vertical
space, but also changes the formatting somewhat significantly.