### PR TITLE
Use &str in functions

### DIFF
--- a/forma/src/main.rs
+++ b/forma/src/main.rs
@@ -61,7 +61,7 @@ fn main() -> Result<()> {
         // `PathBuf` provided, so let's use that.
         Some(input) => {
             let sql_string = fs::read_to_string(&input)?;
-            let formatted = format(sql_string, check, max_width)?;
+            let formatted = format(&sql_string, check, max_width)?;
             let writer = fs::File::create(input)?;
             write_formatted(writer, formatted)
         }
@@ -70,7 +70,7 @@ fn main() -> Result<()> {
         None => {
             let mut sql_string = String::new();
             io::stdin().lock().read_to_string(&mut sql_string)?;
-            let formatted = format(sql_string, check, max_width)?;
+            let formatted = format(&sql_string, check, max_width)?;
             let writer = io::stdout();
             write_formatted(writer, formatted)
         }

--- a/formation/benches/formation_bench.rs
+++ b/formation/benches/formation_bench.rs
@@ -5,7 +5,7 @@ fn basic_formatting_benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("Formation Formatting");
     let string = "SELECT * FROM bob WHERE 1 = 1";
     group.bench_function("formation::format", |b| {
-        b.iter(|| format(string.to_string(), false, 80));
+        b.iter(|| format(string, false, 80));
     });
 }
 

--- a/formation/src/format.rs
+++ b/formation/src/format.rs
@@ -14,7 +14,7 @@ use crate::doc::render_statement;
 use crate::error::{self, FormaError};
 
 fn format_statement(
-    sql_string: String,
+    sql_string: &str,
     statement: Statement,
     check: bool,
     max_width: usize,
@@ -54,13 +54,13 @@ fn format_statement(
 ///     vec!["select * from users;\n".to_owned()]
 /// );
 /// ```
-pub fn format(sql_string: String, check: bool, max_width: usize) -> error::Result<Vec<String>> {
+pub fn format(sql_string: &str, check: bool, max_width: usize) -> error::Result<Vec<String>> {
     let dialect = TemplatedDialect {};
-    let statements = Parser::parse_sql(&dialect, sql_string.clone())?;
+    let statements = Parser::parse_sql(&dialect, sql_string.to_string())?;
     let mut pretty_statements: Vec<String> = vec![];
 
     for statement in statements {
-        let pretty_statement = format_statement(sql_string.clone(), statement, check, max_width)?;
+        let pretty_statement = format_statement(sql_string, statement, check, max_width)?;
         pretty_statements.push(format!("{};\n", pretty_statement));
     }
 
@@ -77,7 +77,7 @@ mod tests {
 
     #[test]
     fn test_format_statement() {
-        let sql_string = "SELECT 42;".to_owned();
+        let sql_string = "SELECT 42;";
         let statement = Statement::Query(Box::new(Query {
             body: SetExpr::Select(Box::new(Select {
                 distinct: false,

--- a/formation/src/format.rs
+++ b/formation/src/format.rs
@@ -48,7 +48,7 @@ fn format_statement(
 ///
 /// ```
 /// use formation::format;
-/// let sql_string = "SELECT * FROM users;".to_owned();
+/// let sql_string = "SELECT * FROM users;";
 /// assert_eq!(
 ///     format(sql_string, false, 100).unwrap(),
 ///     vec!["select * from users;\n".to_owned()]
@@ -105,7 +105,7 @@ mod tests {
     fn test_format() {
         let sql_string = "select id from users where created_at > {{date}};".to_owned();
         assert_eq!(
-            format(sql_string, false, MAX_WIDTH).unwrap(),
+            format(&sql_string, false, MAX_WIDTH).unwrap(),
             vec!["select id from users where created_at > {{date}};\n".to_owned()]
         );
     }

--- a/formation/tests/format_test.rs
+++ b/formation/tests/format_test.rs
@@ -43,7 +43,7 @@ fn test_format(fixture_paths: (String, String)) {
     let sql_string = fs::read_to_string(input_path.clone())
         .unwrap_or_else(|_| panic!("Could not load fixture input path: {}", input_path));
     assert_eq!(
-        formation::format(sql_string, false, MAX_WIDTH).unwrap(),
+        formation::format(&sql_string, false, MAX_WIDTH).unwrap(),
         vec![fs::read_to_string(expected_path.clone())
             .unwrap_or_else(|_| panic!("Could not load fixture expected path: {}", expected_path))]
     );


### PR DESCRIPTION
* `&str` avoids having to copy the `Strings` before passing it
* Together with the commit https://github.com/andygrove/sqlparser-rs/commit/d32df527e68dd76d857f47ea051a3ec22138469b , we can remove the `to_string()` in the future